### PR TITLE
Fix fixed

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -118,7 +118,7 @@ if (!defined('PASSWORD_BCRYPT')) {
 				$bl = strlen($buffer);
 				for ($i = 0; $i < $raw_length; $i++) {
 					if ($i < $bl) {
-						$buffer ^= chr(mt_rand(0, 255));
+						$buffer[$i] = $buffer[$i] ^ chr(mt_rand(0, 255));
 					} else {
 						$buffer .= chr(mt_rand(0, 255));
 					}


### PR DESCRIPTION
In my previous pull request, the fix was $buffer[$i] ^= ...
But this fails with "Cannot use assign-op operators with overloaded objects nor string offsets"...

So here is the proper fix
