### PR TITLE
Phalanger Fix

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -82,7 +82,7 @@ if (!defined('PASSWORD_BCRYPT')) {
 			$buffer = '';
 			$raw_length = (int) ($required_salt_len * 3 / 4 + 1);
 			$buffer_valid = false;
-			if (function_exists('mcrypt_create_iv')) {
+			if (function_exists('mcrypt_create_iv') && !defined('PHALANGER')) {
 				$buffer = mcrypt_create_iv($raw_length, MCRYPT_DEV_URANDOM);
 				if ($buffer) {
 					$buffer_valid = true;


### PR DESCRIPTION
While mcrypt_create_iv and MCRYPT_DEV_URANDOM are both available in Phalanger, when used it will generate a warning stating that the file (/dev/urandom) cannot be read from.

The !$buffer_valid check would catch this, however there would still be a warning generated every time a password was hashed.

In my opinion it is best to check if Phalanger is being used, and prevent this path from executing in the first place.
