### PR TITLE
Fix for potential forward compatibility break.

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -7,7 +7,7 @@
  * @copyright 2012 The Authors
  */
 
-if (!defined('PASSWORD_BCRYPT')) {
+if (!defined('PASSWORD_DEFAULT')) {
 
     define('PASSWORD_BCRYPT', 1);
     define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);


### PR DESCRIPTION
Since this is supposed to be forward compatible.  What happens if BCRYPT is pulled one day for any reason?  This would break forward compatibility, but relying on PASSWORD_DEFAULT should be safe.

I think another option would be:

if ( ! function_exists('password_hash') ) {
}
