### PR TITLE
Generic formula to calculate $raw_salt_len

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -45,10 +45,10 @@ if (!defined('PASSWORD_DEFAULT')) {
                         return null;
                     }
                 }
-                // The length of salt to generate
-                $raw_salt_len = 16;
                 // The length required in the final serialization
                 $required_salt_len = 22;
+                // The length of salt to generate
+                $raw_salt_len = (int)($required_salt_len * 0.75 + 0.25);
                 $hash_format = sprintf("$2y$%02d$", $cost);
                 break;
             default:


### PR DESCRIPTION
Added a generic formula to calculate $raw_salt_len, it will always return the value for least amount of data required for a given $required_salt_len.
