### PR TITLE
 README: Popped in a link to the details of the security issue with bcrypt before 5.3.7...

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The runtime checks have been removed due to this version issue. To see if passwo
 
 If you attempt to use password-compat on an unsupported version, attempts to create or verify hashes will return `false`. You have been warned!
 
-The reason for this is that PHP prior to 5.3.7 contains a security issue with its BCRYPT implementation. Therefore, it's highly recommended that you upgrade to a newer version of PHP prior to using this layer.
+The reason for this is that PHP prior to 5.3.7 contains a [security issue with its BCRYPT implementation](http://php.net/security/crypt_blowfish.php). Therefore, it's highly recommended that you upgrade to a newer version of PHP prior to using this layer.
 
 Installation
 ============


### PR DESCRIPTION
..., for clarity & easy reference.
