### PR TITLE
Incorrect encoding of raw salt

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -55,6 +55,7 @@ if (!defined('PASSWORD_DEFAULT')) {
                 trigger_error(sprintf("password_hash(): Unknown password hashing algorithm: %s", $algo), E_USER_WARNING);
                 return null;
         }
+        $salt_requires_encoding = false;
         if (isset($options['salt'])) {
             switch (gettype($options['salt'])) {
                 case 'NULL':
@@ -79,7 +80,7 @@ if (!defined('PASSWORD_DEFAULT')) {
                 trigger_error(sprintf("password_hash(): Provided salt is too short: %d expecting %d", strlen($salt), $required_salt_len), E_USER_WARNING);
                 return null;
             } elseif (0 == preg_match('#^[a-zA-Z0-9./]+$#D', $salt)) {
-                $salt = str_replace('+', '.', base64_encode($salt));
+                $salt_requires_encoding = true;
             }
         } else {
             $buffer = '';
@@ -118,7 +119,18 @@ if (!defined('PASSWORD_DEFAULT')) {
                     }
                 }
             }
-            $salt = str_replace('+', '.', base64_encode($buffer));
+            $salt = $buffer;
+            $salt_requires_encoding = true;
+        }
+        if ($salt_requires_encoding) {
+            // encode string with the Base64 variant used by crypt
+            $base64_digits =
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+            $bcrypt64_digits =
+                './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+            $base64_string = base64_encode($salt);
+            $salt = strtr(rtrim($base64_string, '='), $base64_digits, $bcrypt64_digits);
         }
         $salt = substr($salt, 0, $required_salt_len);
 

--- a/test/Unit/PasswordHashTest.php
+++ b/test/Unit/PasswordHashTest.php
@@ -22,7 +22,7 @@ class PasswordHashTest extends PHPUnit_Framework_TestCase {
 
     public function testRawSalt() {
         $hash = password_hash("test", PASSWORD_BCRYPT, array("salt" => "123456789012345678901" . chr(0)));
-        $this->assertEquals('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', $hash);
+        $this->assertEquals('$2y$10$KRGxLBS0Lxe3KBCwKxOzLexLDeu0ZfqJAKTubOfy7O/yL2hjimw3u', $hash);
     }
 
     /**


### PR DESCRIPTION
The library encodes a raw salt by applying common Base64, removing the padding and replacing “+” with “.”. This is _not_ how the Base64 variant of bcrypt works. In bcrypt, the Base64 digits have completely different values:

Common Base64 is

```
ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
```

bcrypt Base64 is

```
./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
```

As a result, the library is incompatible with common bcrypt implementations when you pass a raw salt. This can easily be tested with PHPass which uses correct encoding. For example, a cost of 10 with the salt 0x00...00 (16 bytes) should result in

```
$2y$10$......................Y.ZR0C94dLJxYMB7aLoGRMNOqWmz51u
```

But password_compat instead returns

```
$2y$10$AAAAAAAAAAAAAAAAAAAAA.sY4I5nDHsL5ufSOH0P.gICQkhzJWhMS
```

Also note how the 22nd salt digit “inexplicibly” turns into “.” (see below).

The wrong encoding also leads to a nonsensical 22nd salt digit. For example, if the last two bits of the raw salt are 0b11, then the last digit should be “u” which represents 0b110000. Instead, the wrong encoding will yield the digit “w” which represents 0b1100[1]0 in bcrypt. Since the salt only covers the first two bits (the rest is padding), this digit makes no sense.

Fortunately, the current bcrypt implementation doesn’t choke on this. It automatically corrects the 22nd digit by nullifying all bits except the first two. However, this makes the library inconsistent in the sense that encoding the raw input salt yields a different result than what is in the calculated hash:

``` php
$raw_salt = str_repeat("\x12", 22);

// encode salt using your method:
echo substr(str_replace('+', '.', base64_encode($raw_salt)), 0, 22), '<br>';
// the encoded salt is "EhISEhISEhISEhISEhISE[h]"

// calculate hash from raw salt:
echo password_hash('foo', PASSWORD_BCRYPT, array('salt' => $raw_salt));
// now we suddenly have "EhISEhISEhISEhISEhISE[e]"
```
