### PR TITLE
Prevent warnings from open_basedir

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -96,7 +96,7 @@ if (!defined('PASSWORD_DEFAULT')) {
                     $buffer_valid = true;
                 }
             }
-            if (!$buffer_valid && is_readable('/dev/urandom')) {
+            if (!$buffer_valid && @is_readable('/dev/urandom')) {
                 $f = fopen('/dev/urandom', 'r');
                 $read = strlen($buffer);
                 while ($read < $raw_salt_len) {


### PR DESCRIPTION
If `open_basedir` is turned on, the call `is_readable('/dev/urandom')` will always generate a warning. This may flood the error log and is also completely nonsensical on systems which do not even have `/dev/urandom`.
