### PR TITLE
Require PHP 5.3.7 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
 			"homepage": "http://blog.ircmaxell.com"
 		}
 	],
+	"require": {
+		"php": ">=5.3.7"
+	},
     "require-dev": {
         "phpunit/phpunit": "3.7"
     },


### PR DESCRIPTION
PHP 5.3.0 adds the bcrypt algorithm baked in. So this is a requirement. 
However in PHP 5.3.7 a security issue was fixed and the algorithm updated. So
using anything below `5.3.7` is not an option for such a library aiming at
security.
