### PR TITLE
document php min version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
 			"homepage": "http://blog.ircmaxell.com"
 		}
 	],
+    "require": {
+	"php": ">=5.3.7",
+    },
     "require-dev": {
         "phpunit/phpunit": "4.*"
     },


### PR DESCRIPTION
since it is still compatible with 5.5,5.6 while disabling itself automatically, I will not exclude those version from a composer point of view.

see also https://github.com/ircmaxell/password_compat/pull/61#issuecomment-54478599
