### PR TITLE
Make tests run with process isolation work

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -13,6 +13,9 @@ if (!defined('PASSWORD_DEFAULT')) {
 
     define('PASSWORD_BCRYPT', 1);
     define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);
+}
+
+if (!function_exists('password_hash')) {
 
     /**
      * Hash the password using the specified algorithm
@@ -149,6 +152,9 @@ if (!defined('PASSWORD_DEFAULT')) {
 
         return $ret;
     }
+}
+
+if (!function_exists('password_get_info')) {
 
     /**
      * Get information about the password hash. Returns an array of the information
@@ -180,6 +186,9 @@ if (!defined('PASSWORD_DEFAULT')) {
         }
         return $return;
     }
+}
+
+if (!function_exists('password_needs_rehash')) {
 
     /**
      * Determine if the password hash needs to be rehashed according to the options provided
@@ -207,6 +216,9 @@ if (!defined('PASSWORD_DEFAULT')) {
         }
         return false;
     }
+}
+
+if (!function_exists('password_verify')) {
 
     /**
      * Verify a password against a hash using a timing attack resistant approach

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
          mapTestClassNameToCoveredClassName="false"
-         processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"

--- a/test/Unit/PasswordGetInfoTest.php
+++ b/test/Unit/PasswordGetInfoTest.php
@@ -15,6 +15,13 @@ class PasswordGetInfoTest extends PHPUnit_Framework_TestCase {
     public function testFuncExists() {
         $this->assertTrue(function_exists('password_get_info'));
     }
+    
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFuncExistsSeparateProc() {
+        $this->assertTrue(function_exists('password_get_info'));
+    }
 
     /**
      * @dataProvider provideInfo

--- a/test/Unit/PasswordHashTest.php
+++ b/test/Unit/PasswordHashTest.php
@@ -5,6 +5,13 @@ class PasswordHashTest extends PHPUnit_Framework_TestCase {
     public function testFuncExists() {
         $this->assertTrue(function_exists('password_hash'));
     }
+    
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFuncExistsSeparateProc() {
+        $this->assertTrue(function_exists('password_hash'));
+    }
 
     public function testStringLength() {
         $this->assertEquals(60, strlen(password_hash('foo', PASSWORD_BCRYPT)));

--- a/test/Unit/PasswordNeedsRehashTest.php
+++ b/test/Unit/PasswordNeedsRehashTest.php
@@ -15,6 +15,13 @@ class PasswordNeedsRehashTest extends PHPUnit_Framework_TestCase {
     public function testFuncExists() {
         $this->assertTrue(function_exists('password_needs_rehash'));
     }
+    
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFuncExistsSeparateProc() {
+        $this->assertTrue(function_exists('password_needs_rehash'));
+    }
 
     /**
      * @dataProvider provideCases

--- a/test/Unit/PasswordVerifyTest.php
+++ b/test/Unit/PasswordVerifyTest.php
@@ -5,6 +5,13 @@ class PasswordVerifyTest extends PHPUnit_Framework_TestCase {
     public function testFuncExists() {
         $this->assertTrue(function_exists('password_verify'));
     }
+    
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFuncExistsSeparateProc() {
+        $this->assertTrue(function_exists('password_verify'));
+    }
 
     public function testFailedType() {
         $this->assertFalse(password_verify(123, 123));


### PR DESCRIPTION
When running phpunit tests with process isolation, the DEFINES executed
by the parent process are passed along to the child proc that actually
runs the test. Disabling "preserveGlobalState" does not affect these
DEFINES, they still are defined for the child. Read more at

https://github.com/sebastianbergmann/phpunit/issues/314

Making the definition of the "password_*" commands conditional on
whether the PASSWORD_DEFAULT define has been set means that child
test procs don't ever get those functions defined. Only the master proc
which doesn't run any tests has them.
