### PR TITLE
Exclude build/development tools from releases using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitignore       export-ignore
+/.gitattributes   export-ignore
+/.travis.yml      export-ignore
+/test             export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
It is conventional to exclude build/development scripts from published packages.

See https://github.com/laravel/framework/blob/master/.gitattributes for one of many examples.
