### PR TITLE
compatibility with sha512

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -73,7 +73,7 @@ if (!defined('PASSWORD_DEFAULT')) {
                 $required_salt_len = 22;
                 $hash_format = sprintf('$6$rounds=%d$', $rounds);
                 // The expected length of the final crypt() output
-                $resultLength = strlen($hash_format) + $raw_salt_len + 86;
+                $resultLength = strlen($hash_format) + $raw_salt_len + 87;
                 break;
             default:
                 trigger_error(sprintf("password_hash(): Unknown password hashing algorithm: %s", $algo), E_USER_WARNING);


### PR DESCRIPTION
These changes add support for sha512 hashing algorithm. This is often required for compatibility with applications that don't support bcrypt.

I am far from an expert on this level, but these changes work fine on our setup. What are your thoughts?
