### PR TITLE
eleminated some calls to 'strlen'

### DIFF
--- a/lib/password.php
+++ b/lib/password.php
@@ -114,25 +114,20 @@ namespace {
                     }
                 }
                 if (!$buffer_valid && @is_readable('/dev/urandom')) {
+                    $buffer = '';
+                    $read = 0;
                     $file = fopen('/dev/urandom', 'r');
-                    $read = PasswordCompat\binary\_strlen($buffer);
                     while ($read < $raw_salt_len) {
                         $buffer .= fread($file, $raw_salt_len - $read);
                         $read = PasswordCompat\binary\_strlen($buffer);
                     }
                     fclose($file);
-                    if ($read >= $raw_salt_len) {
-                        $buffer_valid = true;
-                    }
+                    $buffer_valid = true;
                 }
-                if (!$buffer_valid || PasswordCompat\binary\_strlen($buffer) < $raw_salt_len) {
-                    $buffer_length = PasswordCompat\binary\_strlen($buffer);
+                if (!$buffer_valid) {
+                    $buffer = '';
                     for ($i = 0; $i < $raw_salt_len; $i++) {
-                        if ($i < $buffer_length) {
-                            $buffer[$i] = $buffer[$i] ^ chr(mt_rand(0, 255));
-                        } else {
-                            $buffer .= chr(mt_rand(0, 255));
-                        }
+                        $buffer .= chr(mt_rand(0, 255));
                     }
                 }
                 $salt = $buffer;
@@ -233,12 +228,13 @@ namespace {
                 return false;
             }
             $ret = crypt($password, $hash);
-            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash) || PasswordCompat\binary\_strlen($ret) <= 13) {
+            $l_ret = PasswordCompat\binary\_strlen($ret);
+            if (!is_string($ret) || ($l_ret != PasswordCompat\binary\_strlen($hash)) || ($l_ret <= 13)) {
                 return false;
             }
 
             $status = 0;
-            for ($i = 0; $i < PasswordCompat\binary\_strlen($ret); $i++) {
+            for ($i = 0; $i < $l_ret; $i++) {
                 $status |= (ord($ret[$i]) ^ ord($hash[$i]));
             }
 


### PR DESCRIPTION
When 'password_hash' generates the salt itself it might encounter a small glitch (no real problem, only unnecessary calls) :

Assuming it calls either (or both) of »mcrypt_create_iv« or »openssl_random_pseudo_bytes« »$buffer_valid« could still be FALSE after both if's meaning it might try urandom next.

Sadly buffer now is no longer an empty string but »FALSE« itself!
While it will give the correct result, it is an unnecessary call to »_strlen« just to get 0.
Instead »$read« could be initialized to 0 directly.

Also you are using a while-loop to read from urandom, which won't terminate until we have read enough, meaning the last if for this block is unnecessary, we already know that »$read« is greater or equal to »$raw_salt_len« and we can simply set »$buffer_valid« as true… 

Next: past this point we have either a valid buffer, which per definition has a length of at least »$raw_salt_len«, or it's not valid, making the length check for the following if unnecessary…
But, like the case of trying urandom, »$buffer« should be reinitialized as '' for clean code and the loop could be simplified, alas we know that we are beyond the end of »$buffer«… 

For »password_verify« it's also possible to eliminate 2 calls (one of them inside the loop) to »_strlen« by caching the length of »$ret«.

Hope I haven't overlooked anything and would like to hear your opinion on my changes…