### PR TITLE
Accept DES hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 phpunit.xml
 vendor
+.php-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 composer.lock
 phpunit.xml
 vendor
-.php-version

--- a/lib/password.php
+++ b/lib/password.php
@@ -12,7 +12,7 @@ namespace {
     if (!defined('PASSWORD_BCRYPT')) {
         /**
          * PHPUnit Process isolation caches constants, but not function declarations.
-         * So we need to check if the constants are defined separately from 
+         * So we need to check if the constants are defined separately from
          * the functions to enable supporting process isolation in userland
          * code.
          */
@@ -236,7 +236,7 @@ namespace {
                 return false;
             }
             $ret = crypt($password, $hash);
-            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash) || PasswordCompat\binary\_strlen($ret) <= 13) {
+            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash) || PasswordCompat\binary\_strlen($ret) < 13) {
                 return false;
             }
 

--- a/test/Unit/PasswordVerifyTest.php
+++ b/test/Unit/PasswordVerifyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 class PasswordVerifyTest extends PHPUnit_Framework_TestCase {
-    
+
     public function testFuncExists() {
         $this->assertTrue(function_exists('password_verify'));
     }
@@ -24,6 +24,10 @@ class PasswordVerifyTest extends PHPUnit_Framework_TestCase {
 
     public function testInValidHash() {
         $this->assertFalse(password_verify('rasmuslerdorf', '$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hj'));
+    }
+
+    public function testDesHashesAreAccepted() {
+        $this->assertTrue(password_verify('rasmuslerdorf', crypt('rasmuslerdorf', 'AB')));
     }
 
 }


### PR DESCRIPTION
Native password_verify() **does** accept old insecure DES hashes (https://3v4l.org/hKl4X). This pull request re-enables verifying (but not creating) them.
