### PR TITLE
Use random_compat and constant-time base64 encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
             "homepage": "http://blog.ircmaxell.com"
         }
     ],
+    "require": {
+        "paragonie/constant_time_encoding": "^0.4",
+        "paragonie/random_compat": "^1.2"
+    },
     "require-dev": {
         "phpunit/phpunit": "4.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "paragonie/constant_time_encoding": "^0.4",
+        "paragonie/constant_time_encoding": "^1.0",
         "paragonie/random_compat": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
This patch:

* Uses random_compat for salt generation, which is usually better than openssl
* Uses constant_time_encoding for a crypt-compatible salt format